### PR TITLE
allow bind to 0.0.0.0

### DIFF
--- a/Source/URoboVision/Private/RGBDCamera.cpp
+++ b/Source/URoboVision/Private/RGBDCamera.cpp
@@ -88,6 +88,7 @@ ARGBDCamera::ARGBDCamera() /*: ACameraActor(), Width(960), Height(540), Framerat
 	
 	// TCP IP communication server port
 	ServerPort = 10000;
+  bBindToAnyIP = true;
 
 	// Setting flags for each camera
 	ShowFlagsLit(ColorImgCaptureComp->ShowFlags);
@@ -134,7 +135,7 @@ void ARGBDCamera::BeginPlay()
 	OUT_INFO(TEXT("Begin play!"));
 
 	// Starting server
-	Priv->Server.Start(ServerPort);
+	Priv->Server.Start(ServerPort, bBindToAnyIP);
 
 	// Coloring all objects
 	ColorAllObjects();

--- a/Source/URoboVision/Private/RGBDCamera.cpp
+++ b/Source/URoboVision/Private/RGBDCamera.cpp
@@ -88,7 +88,7 @@ ARGBDCamera::ARGBDCamera() /*: ACameraActor(), Width(960), Height(540), Framerat
 	
 	// TCP IP communication server port
 	ServerPort = 10000;
-  bBindToAnyIP = true;
+	bBindToAnyIP = true;
 
 	// Setting flags for each camera
 	ShowFlagsLit(ColorImgCaptureComp->ShowFlags);

--- a/Source/URoboVision/Private/Server.cpp
+++ b/Source/URoboVision/Private/Server.cpp
@@ -16,7 +16,7 @@ TCPServer::~TCPServer()
   }
 }
 
-void TCPServer::Start(const int32 ServerPort)
+void TCPServer::Start(const int32 ServerPort, bool BindToAnyIp)
 {
   OUT_INFO(TEXT("Starting server."));
 
@@ -31,6 +31,17 @@ void TCPServer::Start(const int32 ServerPort)
   bool bCanBind = false;
   TSharedRef<FInternetAddr> LocalIP = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->GetLocalHostAddr(*GLog, bCanBind);
   LocalIP->SetPort(ServerPort);
+
+  if(BindToAnyIp)
+  {
+    bool isValid;
+    LocalIP->SetIp(TEXT("0.0.0.0"),isValid);
+    if(!isValid)
+    {
+      OUT_ERROR(TEXT("Coulnd't force address to 0.0.0.0"));
+    }
+  }
+
   OUT_INFO(TEXT("Server address: %s"), *LocalIP->ToString(true));
 
   ListenSocket = ISocketSubsystem::Get(PLATFORM_SOCKETSUBSYSTEM)->CreateSocket(NAME_Stream, TEXT("Server Listening Socket"), false);

--- a/Source/URoboVision/Private/Server.h
+++ b/Source/URoboVision/Private/Server.h
@@ -26,7 +26,7 @@ public:
   TCPServer();
   ~TCPServer();
 
-  void Start(const int32 ServerPort);
+  void Start(const int32 ServerPort, bool BindToAnyIp);
   void Stop();
 
   bool HasClient() const;

--- a/Source/URoboVision/Public/RGBDCamera.h
+++ b/Source/URoboVision/Public/RGBDCamera.h
@@ -60,6 +60,15 @@ public:
 	UPROPERTY(EditAnywhere, Category = "RGB-D Settings")
 	int32 ServerPort;
 
+	// Create the server port on 0.0.0.0
+	// By enabling this, you can connect to the server
+	// via your 127.0.0.1 or your 'real' ip like 192....
+	// Please be aware that binding to 0.0.0.0 will
+	// allow connections from any network adapter
+	// on your system
+	UPROPERTY(EditAnywhere, Category = "RGB-D Settings")
+	bool bBindToAnyIP;
+
 	// Capture color image
 	UPROPERTY(EditAnywhere, Category = "RGB-D Settings")
 	bool bCaptureColorImage;


### PR DESCRIPTION
This PR will allow the Vision Server to be bound to 0.0.0.0, which will not only accept connections from your network adapters address (for example 192...) but also from 127.0.0.1
When executing urobovision on the same machine as on your urobovision client, you don't have to adjust your client settings with your current ip address anymore, but can just connect to 127.0.0.1.