### PR TITLE
Make the Plugin backward compatible and some fixes on the parameter initialization

### DIFF
--- a/Source/URoboVision/Private/StaticSegmentationSceneProxy.cpp
+++ b/Source/URoboVision/Private/StaticSegmentationSceneProxy.cpp
@@ -5,7 +5,11 @@
 FStaticSegmentationSceneProxy::FStaticSegmentationSceneProxy(UStaticMeshComponent* Component, bool bForceLODsShareStaticLighting, UMaterialInterface* SegmentationMID) :
 		FStaticMeshSceneProxy(Component, bForceLODsShareStaticLighting)
 	{
+	#if (ENGINE_MINOR_VERSION >= 22)
 		MaterialRenderProxy = SegmentationMID->GetRenderProxy();
+	#else
+		MaterialRenderProxy = SegmentationMID->GetRenderProxy(false, false);
+	#endif
 		this->MaterialRelevance = SegmentationMID->GetRelevance(GetScene().GetFeatureLevel());
 		this->bVerifyUsedMaterials = false;
 		bCastShadow = false;
@@ -40,12 +44,23 @@ bool FStaticSegmentationSceneProxy::GetMeshElement(
 	int32 BatchIndex,
 	int32 ElementIndex,
 	uint8 InDepthPriorityGroup,
-        bool bUseSelectionOutline,
+#if (ENGINE_MINOR_VERSION >= 22)
+	bool bUseSelectionOutline,
+#else
+	bool bUseSelectedMaterial,
+	bool bUseHoveredMaterial,
+#endif
 	bool bAllowPreCulledIndices,
 	FMeshBatch & OutMeshBatch) const
 {
 	bool Ret = FStaticMeshSceneProxy::GetMeshElement(LODIndex, BatchIndex, ElementIndex, InDepthPriorityGroup,
-		bUseSelectionOutline, bAllowPreCulledIndices, OutMeshBatch);
+#if (ENGINE_MINOR_VERSION >= 22)
+	bUseSelectionOutline,
+#else
+	bUseSelectedMaterial,
+	bUseHoveredMaterial,
+#endif
+	bAllowPreCulledIndices, OutMeshBatch);
 	OutMeshBatch.MaterialRenderProxy = this->MaterialRenderProxy;
 	return Ret;
 }

--- a/Source/URoboVision/Public/StaticSegmentationSceneProxy.h
+++ b/Source/URoboVision/Public/StaticSegmentationSceneProxy.h
@@ -30,7 +30,12 @@ public:
 		int32 BatchIndex,
 		int32 ElementIndex,
 		uint8 InDepthPriorityGroup,
+	#if (ENGINE_MINOR_VERSION >= 22)
 		bool bUseSelectionOutline,
+	#else
+		bool bUseSelectedMaterial,
+		bool bUseHoveredMaterial,
+	#endif
 		bool bAllowPreCulledIndices,
 		FMeshBatch & OutMeshBatch
 	) const override;


### PR DESCRIPTION
Hi!

I've add version macros to ensure backward compatibility on the changes introduced for 4.22.
Additionally,  this PR moves buffer initialization to BeginPlay() to correctly init the buffer with the cameras values read in beginplay (analogous to the render init). Instead of using purely setting sizeX and sizeY for the RenderTarget initialization, the plugin is now using InitAutoFormat on RenderTarget because it internally calls an updateResource method. 
Renamed variable in ReadImage to get rid of shadowing variables (fixes a compiler warning).

