### PR TITLE
Changed ColorAllObjects() to fix problems when bColorAllObjectsOnEveryTick is true

### DIFF
--- a/Source/URoboVision/Private/RGBDCamera.cpp
+++ b/Source/URoboVision/Private/RGBDCamera.cpp
@@ -588,7 +588,7 @@ bool ARGBDCamera::ColorAllObjects()
 	}
   
 	if(bColoringObjectsIsVerbose)
-  {
+	{
 		OUT_INFO(TEXT("Found %d Actors."), NumberOfActors);
 		OUT_INFO(TEXT("The current object-to-color mapping contains %d entries."), ObjectToColor.Num());
   }

--- a/Source/URoboVision/Private/RGBDCamera.cpp
+++ b/Source/URoboVision/Private/RGBDCamera.cpp
@@ -591,7 +591,7 @@ bool ARGBDCamera::ColorAllObjects()
 	{
 		OUT_INFO(TEXT("Found %d Actors."), NumberOfActors);
 		OUT_INFO(TEXT("The current object-to-color mapping contains %d entries."), ObjectToColor.Num());
-  }
+	}
 
 	if(!bColorAllObjectsOnEveryTick)
 		GenerateColors(NumberOfActors * 2);

--- a/Source/URoboVision/Private/RGBDCamera.cpp
+++ b/Source/URoboVision/Private/RGBDCamera.cpp
@@ -86,6 +86,7 @@ ARGBDCamera::ARGBDCamera() /*: ACameraActor(), Width(960), Height(540), Framerat
 
 	bColorAllObjectsOnEveryTick = false;
 	bColoringObjectsIsVerbose = false;
+	ColorGenerationMaximumAmount = 0;
 
 	// Setting flags for each camera
 	ShowFlagsLit(ColorImgCaptureComp->ShowFlags);
@@ -136,6 +137,20 @@ void ARGBDCamera::BeginPlay()
 	Priv->Server.Start(ServerPort, bBindToAnyIP);
 
 	// Coloring all objects
+	// If colors will be reassigned on every tick, we have to
+	// reserve the right amount of colors now.
+	if(bColorAllObjectsOnEveryTick)
+	{
+		if(ColorGenerationMaximumAmount == 0){
+			OUT_WARN(TEXT("You've set bColorAllObjectsOnEveryTick to true, but didn't set a ColorGenerationMaximumAmount! Will set a default of 10000 now."));
+			GenerateColors(10000);
+		}
+		else
+		{
+			GenerateColors(ColorGenerationMaximumAmount);
+		}
+	}
+
 	ColorAllObjects();
 
 	Running = true;
@@ -234,6 +249,8 @@ void ARGBDCamera::Tick(float DeltaTime)
 
 	if(bColorAllObjectsOnEveryTick)
 	{
+		// Remove all old object color mapping information
+		RemoveNonExistingActorsFromColorMap();
 		// Coloring all objects again to color new objects added after BeginPlay()
 		ColorAllObjects();
 	}
@@ -571,8 +588,13 @@ bool ARGBDCamera::ColorAllObjects()
 	}
   
 	if(bColoringObjectsIsVerbose)
+  {
 		OUT_INFO(TEXT("Found %d Actors."), NumberOfActors);
-	GenerateColors(NumberOfActors * 2);
+		OUT_INFO(TEXT("The current object-to-color mapping contains %d entries."), ObjectToColor.Num());
+  }
+
+	if(!bColorAllObjectsOnEveryTick)
+		GenerateColors(NumberOfActors * 2);
 
 	for(TActorIterator<AActor> ActItr(GetWorld()); ActItr; ++ActItr)
 	{
@@ -580,18 +602,61 @@ bool ARGBDCamera::ColorAllObjects()
 		if(!ObjectToColor.Contains(ActorName))
 		{
 			check(ColorsUsed < (uint32)ObjectColors.Num());
-			ObjectToColor.Add(ActorName, ColorsUsed);
-			if(bColoringObjectsIsVerbose)
-				OUT_INFO(TEXT("Adding color %d for object %s."), ColorsUsed, *ActorName);
 
-			++ColorsUsed;
+			uint32 ColorToAssign;
+
+			bool UsedAFreedColor = false;
+			if(FreedColors.Num() > 0)
+			{
+				ColorToAssign = FreedColors.Pop();
+				UsedAFreedColor = true;
+			}else{
+				ColorToAssign = ColorsUsed;
+			}
+
+			ObjectToColor.Add(ActorName, ColorToAssign);
+			if(bColoringObjectsIsVerbose)
+				OUT_INFO(TEXT("Adding color %d for object %s."), ColorToAssign, *ActorName);
+
+			// If we didn't used one of the free colors,
+			// we have to increment our global color counter
+			if(!UsedAFreedColor)
+				++ColorsUsed;
 		}
 
 		if(bColoringObjectsIsVerbose)
 			OUT_INFO(TEXT("Coloring object %s."), *ActorName);
+
 		ColorObject(*ActItr, ActorName);
 	}
 	return true;
+}
+
+void ARGBDCamera::RemoveNonExistingActorsFromColorMap()
+{
+  TArray<FString> AllActors;
+
+	for(TActorIterator<AActor> ActItr(GetWorld()); ActItr; ++ActItr)
+	{
+		FString ActorName = ActItr->GetName();
+		AllActors.Add(ActorName);
+	}
+
+	TArray<FString> ObjectColorKeyToBeRemovedArray;
+	for(auto& ObjectColorPair : ObjectToColor)
+	{
+		if(!AllActors.Contains(ObjectColorPair.Key))
+		{
+			ObjectColorKeyToBeRemovedArray.Add(ObjectColorPair.Key);
+
+			// Store the colors that are now available for new objects
+			FreedColors.Add(ObjectColorPair.Value);
+		}
+	}
+	for(auto& ObjectColorKeyToBeRemoved : ObjectColorKeyToBeRemovedArray)
+	{
+		ObjectToColor.Remove(ObjectColorKeyToBeRemoved);
+	}
 }
 
 void ARGBDCamera::ProcessColor()

--- a/Source/URoboVision/Public/RGBDCamera.h
+++ b/Source/URoboVision/Public/RGBDCamera.h
@@ -87,6 +87,11 @@ public:
 	// Activating this flag will assign colors to all actors 
 	// on every tick. This might be necessary if you dynamically add and remove
 	// objects to the scene after BeginPlay()
+  // Please note that when activating this flag, 
+  // the Color Initialization is done only once in BeginPlay()
+  // in conjunction with the ColorGenerationMaximumAmount variable
+  // to generate enough colors for your use case of the whole duration of 
+  // the runtime
 	UPROPERTY(EditAnywhere, Category = "RGB-D Settings")
 	bool bColorAllObjectsOnEveryTick;
 
@@ -94,6 +99,12 @@ public:
 	// to know which objects have been found and their assigned RGB colors
 	UPROPERTY(EditAnywhere, Category = "RGB-D Settings")
 	bool bColoringObjectsIsVerbose;
+
+	// The number of object colors that should be generated 
+  // when using ColorAllObjectsOnEveryTick.
+  // This number must be higher than the amount of Actors you have in your world at any time.
+	UPROPERTY(EditAnywhere, Category = "RGB-D Settings")
+	int ColorGenerationMaximumAmount;
 
 private:
 	// Camera capture component for color images (RGB)
@@ -123,6 +134,7 @@ private:
 	TArray<FColor>ImageColor, ObjectColors;
 	TMap<FString, uint32> ObjectToColor;
 	uint32 ColorsUsed;
+	TArray<uint32> FreedColors;
 	bool Running, Paused;
 
 	void ShowFlagsBasicSetting(FEngineShowFlags &ShowFlags) const;
@@ -138,6 +150,7 @@ private:
 	void GenerateColors(const uint32_t NumberOfColors);
 	bool ColorObject(AActor *Actor, const FString &name);
 	bool ColorAllObjects();
+	void RemoveNonExistingActorsFromColorMap();
 	void ProcessColor();
 	void ProcessDepth();
 	void ProcessObject();


### PR DESCRIPTION
Until now, the generation of colors only needed to be called once and was depended on the maximum numbers of actors in the world. When calling the method multiple times, it could happen that new actors did get the same colors as other actors before, leading to an unusble object color mapping.
This PR will now also delete Actors in the ObjectToColor mapping that don't exist anymore.